### PR TITLE
MacOS SDL2 config update

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -26,7 +26,6 @@ build_flags =
   ; Add recursive dirs for hal headers search
   !python -c "import os; print(' '.join(['-I {}'.format(i[0].replace('\x5C','/')) for i in os.walk('hal/sdl2')]))"
   ; -arch arm64 ; MACOS with apple silicon (eg M1)
-  ; -L /opt/homebrew/Cellar/sdl2/2.0.22/lib/ ; MACOS
   -L C:/msys64/mingw64/lib/ ; Windows
   -lSDL2
   ; SDL drivers options
@@ -41,7 +40,9 @@ build_flags =
   -D SDL_ZOOM=1
   -D SDL_INCLUDE_PATH="\"C:/msys64/mingw64/include/SDL2/SDL.h\"" ; Windows
   ; -D SDL_INCLUDE_PATH="\"SDL2/SDL.h"\" ;MACOS
-  ; -I /opt/homebrew/Cellar/sdl2/2.0.22/include/ ;MACOS
+  ; !find /opt/homebrew/Cellar/sdl2 -name "include" | sed "s/^/-I /" ;MACOS
+  ; !find /opt/homebrew/Cellar/sdl2 -name "libSDL2.a" | xargs dirname | sed "s/^/-L /" ;MACOS
+
   
 lib_deps =
   ${env.lib_deps}


### PR DESCRIPTION
Updated `platformio.ini` to reflect current SDL2 Mac install instructions : https://github.com/lvgl/lv_platformio?tab=readme-ov-file#install-sdl-drivers