### PR TITLE
Wire up real AXP2101 battery reading for lolin_s3_2_06

### DIFF
--- a/hal/esp32/app_hal.cpp
+++ b/hal/esp32/app_hal.cpp
@@ -92,6 +92,10 @@ RtcPCF8563<TwoWire> Rtc(Wire);
 #if ESPS3_2_06
 #include <SensorPCF85063.hpp>
 SensorPCF85063 rtc;
+#define XPOWERS_CHIP_AXP2101
+#include <XPowersLib.h>
+XPowersAXP2101 PMU;
+int watchBatteryPercent = 100; // last known-good AXP2101 reading, used by watch faces + settings
 #endif
 
 #define FLASH FFat
@@ -1935,6 +1939,10 @@ void hal_setup()
 
   ui_init();
 
+#if ESPS3_2_06
+  lv_obj_remove_flag(ui_batterySlider, LV_OBJ_FLAG_CLICKABLE); // real PMU reading, not a fake-level debug control
+#endif
+
   bool fsState = setupFS();
   if (fsState)
   {
@@ -2128,6 +2136,23 @@ void hal_setup()
 	watch.setTime(dt.getSecond(), dt.getMinute(), dt.getHour(), dt.getDay(), dt.getMonth(), dt.getYear());
 	rtc.resetAlarm();
 	rtc.disableAlarm();
+
+  if (!PMU.init(Wire, TOUCH_SDA, TOUCH_SCL, AXP2101_SLAVE_ADDRESS))
+  {
+    Timber.e("Failed to find AXP2101 - check your wiring!");
+  }
+  else
+  {
+    int pct = PMU.getBatteryPercent();
+    Timber.i("AXP2101 battery: %d%%, charging: %d, vbus: %d", pct, PMU.isCharging(), PMU.isVbusIn());
+    if (pct >= 0)
+    {
+      watchBatteryPercent = pct;
+      watch.setBattery(pct, PMU.isCharging());
+      lv_slider_set_value(ui_batterySlider, watchBatteryPercent, LV_ANIM_OFF);
+      lv_label_set_text_fmt(ui_batteryLabel, "Battery %d%%", watchBatteryPercent);
+    }
+  }
 #endif
 
   ui_update_seconds(watch.getSecond());
@@ -2325,6 +2350,24 @@ void hal_loop()
       }
     }
 
+#if ESPS3_2_06
+    {
+      static unsigned long lastBatteryPoll = 0;
+      if (millis() - lastBatteryPoll >= 30000)
+      {
+        lastBatteryPoll = millis();
+        int pct = PMU.getBatteryPercent();
+        if (pct >= 0)
+        {
+          watchBatteryPercent = pct;
+          watch.setBattery(pct, PMU.isCharging());
+          lv_slider_set_value(ui_batterySlider, watchBatteryPercent, LV_ANIM_OFF);
+          lv_label_set_text_fmt(ui_batteryLabel, "Battery %d%%", watchBatteryPercent);
+        }
+      }
+    }
+#endif
+
     if (screenTimer.active)
     {
       uint8_t lvl = lv_slider_get_value(ui_brightnessSlider);
@@ -2446,7 +2489,11 @@ void update_faces()
   int temp = watch.getWeatherAt(0).temp;
   int icon = watch.getWeatherAt(0).icon;
 
+#if ESPS3_2_06
+  int battery = watchBatteryPercent;
+#else
   int battery = watch.getPhoneBattery();
+#endif
   bool connection = watch.isConnected();
 
   int steps = 2735;

--- a/platformio.ini
+++ b/platformio.ini
@@ -357,10 +357,11 @@ build_src_filter = ${esp32.build_src_filter}
 extends = esp32
 board = lolin_s3_pro
 board_build.partitions = partitions_16M.csv
-lib_deps = 
+lib_deps =
 	${esp32.lib_deps}
 	moononournation/GFX Library for Arduino@1.5.7
 	lewisxhe/SensorLib@0.3.1
+	lewisxhe/XPowersLib@0.3.3
 	FastIMU=https://github.com/LiquidCGS/FastIMU/archive/refs/tags/1.2.6.zip
 build_flags = 
 	${esp32.build_flags}


### PR DESCRIPTION
## Summary
- Watch faces on the Waveshare ESP32-S3-Touch-AMOLED-2.06 (`env:lolin_s3_2_06`) were showing the connected phone's battery level, not the watch's own, since `watch.getPhoneBattery()` was the only value ever fed to `update_faces()` and the watch's own level had no public getter.
- The "Battery" slider in Settings was a user-draggable debug control with no link to real hardware at all.
- Adds real `XPowersLib`-based `PMU.getBatteryPercent()` / `isCharging()` reads (boot-time + a 30s poll in `hal_loop()`), tracked in a `watchBatteryPercent` global, feeding both `update_faces()` and the Settings UI. The slider is now read-only (`LV_OBJ_FLAG_CLICKABLE` removed) since it reflects real hardware.
- Entirely `ESPS3_2_06`-gated (`#if ESPS3_2_06` / `#else`) — every other board's behavior (phone battery via `getPhoneBattery()`, draggable debug slider) is untouched.

## Test plan
- [x] Built clean: `pio run -e lolin_s3_2_06`
- [x] Flashed to a Waveshare ESP32-S3-Touch-AMOLED-2.06, confirmed boot log shows a real reading: `AXP2101 battery: 100%, charging: 0, vbus: 1` (matches actual state: on USB power, battery already full)
- [ ] Not yet confirmed: behavior on battery-only power (no VBUS) or mid-charge (0 < pct < 100, charging=1) — only "full + plugged in" observed so far
- [ ] Not yet confirmed: whether other AXP2101/XPowersLib-equipped boards in this repo could share this pattern (only lolin_s3_2_06 touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)