### PR TITLE
Fix 1167_410 battery bar wraparound and missing ones-digit

### DIFF
--- a/src/faces/1167_410/1167_410.c
+++ b/src/faces/1167_410/1167_410.c
@@ -15,6 +15,7 @@ lv_obj_t *face_1167_410_2_112000;
 lv_obj_t *face_1167_410_3_171192;
 lv_obj_t *face_1167_410_4_171192;
 lv_obj_t *face_1167_410_5_171192;
+lv_obj_t *face_1167_410_47_171192;
 lv_obj_t *face_1167_410_6_175276;
 lv_obj_t *face_1167_410_7_175933;
 lv_obj_t *face_1167_410_8_175933;
@@ -245,6 +246,15 @@ void init_face_1167_410(void (*callback)(const char*, const lv_img_dsc_t *, lv_o
     lv_obj_add_flag(face_1167_410_3_171192, LV_OBJ_FLAG_ADV_HITTEST );
     lv_obj_clear_flag(face_1167_410_3_171192, LV_OBJ_FLAG_SCROLLABLE );
 
+    face_1167_410_47_171192 = lv_img_create(face_1167_410);
+    lv_img_set_src(face_1167_410_47_171192, &face_1167_410_dial_img_3_171192_0);
+    lv_obj_set_width(face_1167_410_47_171192, LV_SIZE_CONTENT);
+    lv_obj_set_height(face_1167_410_47_171192, LV_SIZE_CONTENT);
+    lv_obj_set_x(face_1167_410_47_171192, 206);
+    lv_obj_set_y(face_1167_410_47_171192, 8);
+    lv_obj_add_flag(face_1167_410_47_171192, LV_OBJ_FLAG_ADV_HITTEST );
+    lv_obj_clear_flag(face_1167_410_47_171192, LV_OBJ_FLAG_SCROLLABLE );
+
     face_1167_410_4_171192 = lv_img_create(face_1167_410);
     lv_img_set_src(face_1167_410_4_171192, &face_1167_410_dial_img_3_171192_0);
     lv_obj_set_width(face_1167_410_4_171192, LV_SIZE_CONTENT);
@@ -262,12 +272,13 @@ void init_face_1167_410(void (*callback)(const char*, const lv_img_dsc_t *, lv_o
     lv_obj_set_y(face_1167_410_5_171192, 8);
     lv_obj_add_flag(face_1167_410_5_171192, LV_OBJ_FLAG_ADV_HITTEST );
     lv_obj_clear_flag(face_1167_410_5_171192, LV_OBJ_FLAG_SCROLLABLE );
+    lv_obj_add_flag(face_1167_410_5_171192, LV_OBJ_FLAG_HIDDEN); // battery is 0-100, thousands digit is never meaningful
 
     face_1167_410_6_175276 = lv_img_create(face_1167_410);
     lv_img_set_src(face_1167_410_6_175276, &face_1167_410_dial_img_6_175276_0);
     lv_obj_set_width(face_1167_410_6_175276, LV_SIZE_CONTENT);
     lv_obj_set_height(face_1167_410_6_175276, LV_SIZE_CONTENT);
-    lv_obj_set_x(face_1167_410_6_175276, 210);
+    lv_obj_set_x(face_1167_410_6_175276, 227);
     lv_obj_set_y(face_1167_410_6_175276, 11);
     lv_obj_add_flag(face_1167_410_6_175276, LV_OBJ_FLAG_ADV_HITTEST );
     lv_obj_clear_flag(face_1167_410_6_175276, LV_OBJ_FLAG_SCROLLABLE );
@@ -636,8 +647,9 @@ void update_status_1167_410(int battery, bool connection){
     {
         return;
     }
-	lv_img_set_src(face_1167_410_2_112000, face_1167_410_dial_img_2_112000_group[(battery / (100 / 11)) % 11]);
+	lv_img_set_src(face_1167_410_2_112000, face_1167_410_dial_img_2_112000_group[(battery / 10) % 11]);
 	lv_img_set_src(face_1167_410_3_171192, face_1167_410_dial_img_3_171192_group[(battery / 10) % 10]);
+	lv_img_set_src(face_1167_410_47_171192, face_1167_410_dial_img_3_171192_group[(battery / 1) % 10]);
 	lv_img_set_src(face_1167_410_4_171192, face_1167_410_dial_img_3_171192_group[(battery / 100) % 10]);
 	if (battery < 100)
 	{
@@ -645,7 +657,6 @@ void update_status_1167_410(int battery, bool connection){
 	} else {
 		lv_obj_clear_flag(face_1167_410_4_171192, LV_OBJ_FLAG_HIDDEN);
 	}
-	lv_img_set_src(face_1167_410_5_171192, face_1167_410_dial_img_3_171192_group[(battery / 1000) % 10]);
 
 #endif
 }

--- a/src/faces/1167_410/1167_410.h
+++ b/src/faces/1167_410/1167_410.h
@@ -25,6 +25,7 @@ extern "C"
 	extern lv_obj_t *face_1167_410_3_171192;
 	extern lv_obj_t *face_1167_410_4_171192;
 	extern lv_obj_t *face_1167_410_5_171192;
+	extern lv_obj_t *face_1167_410_47_171192;
 	extern lv_obj_t *face_1167_410_6_175276;
 	extern lv_obj_t *face_1167_410_7_175933;
 	extern lv_obj_t *face_1167_410_8_175933;


### PR DESCRIPTION
## Summary
Two bugs in `update_status_1167_410()` (`src/faces/1167_410/1167_410.c`):

1. **Battery bar drops to empty at full charge.** The 11-frame bar icon was indexed with `(battery / (100 / 11)) % 11`. Integer division truncates `100/11` to `9`, so at `battery=100` the index becomes `(100/9) % 11 = 11 % 11 = 0` — wrapping back to the empty frame right at 100%. Fixed to `(battery / 10) % 11`, which maps `0..100` onto `0..10` directly with no wraparound possible.
2. **Percentage only ever shows a tens digit** (e.g. 40% displays as "4"). Of the three digit-image slots wired up, one showed the tens digit, one showed the hundreds digit (correctly hidden except at exactly 100%), and the third showed `battery/1000` — always zero for a 0-100 value, and left visible unconditionally. Nothing ever computed `battery % 1` (the actual ones digit). Added a new digit image object immediately right of the tens digit, driven by `(battery / 1) % 10`, and hid the always-zero thousands-digit slot (meaningless for a percentage, was just clutter). Moved the adjacent `%` glyph right to clear the new digit.

## Test plan
- [x] Built clean: `pio run -e lolin_s3_2_06`
- [x] Flashed to a Waveshare ESP32-S3-Touch-AMOLED-2.06
- [x] Confirmed on-device: bar now holds full at 100% instead of dropping empty
- [x] Confirmed on-device: percentage now reads correctly as two digits (e.g. "40%") with the `%` clear of the new digit

🤖 Generated with [Claude Code](https://claude.com/claude-code)